### PR TITLE
Updating Economic shock status

### DIFF
--- a/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPostTriggerTests.cs
+++ b/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPostTriggerTests.cs
@@ -238,6 +238,24 @@ namespace NCS.DSS.EmploymentProgression.Tests.FunctionTests
         }
 
         [Test]
+        public async Task Post_SuccessfulRequest_SetDefaultsCalled()
+        {
+            // arrange
+            _httpRequestHelper.Setup(x => x.GetDssTouchpointId(It.IsAny<HttpRequest>())).Returns("0000000001");
+            _httpRequestHelper.Setup(x => x.GetDssApimUrl(It.IsAny<HttpRequest>())).Returns("https://someurl.com");
+            _httpRequestHelper.Setup(x => x.GetResourceFromRequest<Models.EmploymentProgression>(It.IsAny<HttpRequest>())).Returns(Task.FromResult(_employmentProgression));
+            _resourceHelper.Setup(x => x.DoesCustomerExist(It.IsAny<Guid>())).Returns(Task.FromResult(true));
+            _valdiator.Setup(x => x.ValidateResource(It.IsAny<Models.EmploymentProgression>())).Returns(new List<ValidationResult>());
+            _employmentProgressionPostTriggerService.Setup(x => x.CreateEmploymentProgressionAsync(It.IsAny<Models.EmploymentProgression>())).Returns(Task.FromResult(_employmentProgression));
+
+            // Act
+            _ = await RunFunction(ValidCustomerId);
+
+            //Assert
+            _employmentProgressionPostTriggerService.Verify(x => x.SetDefaults(It.IsAny<Models.EmploymentProgression>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
         public async Task Post_SuccessfulRequest_ReturnCreated()
         {
             // arrange

--- a/NCS.DSS.EmploymentProgression.Tests/ServiceTests/EmploymentProgressionPostTriggerServiceTests.cs
+++ b/NCS.DSS.EmploymentProgression.Tests/ServiceTests/EmploymentProgressionPostTriggerServiceTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Moq;
+using NCS.DSS.EmploymentProgression.Cosmos.Provider;
+using NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service;
+using NCS.DSS.EmploymentProgression.ReferenceData;
+using NCS.DSS.EmploymentProgression.ServiceBus;
+using NUnit.Framework;
+
+namespace NCS.DSS.EmploymentProgression.Tests.ServiceTests;
+
+public class EmploymentProgressionPostTriggerServiceTests
+{
+    private EmploymentProgressionPostTriggerService _sut;
+
+    [SetUp]
+    public void Setup()
+    {
+        _sut = new EmploymentProgressionPostTriggerService(new Mock<IDocumentDBProvider>().Object,
+            new Mock<IServiceBusClient>().Object);
+    }
+
+    [Test]
+    [TestCase(EconomicShockStatus.GovernmentDefinedEconomicShock, EconomicShockStatus.GovernmentDefinedEconomicShock)]
+    [TestCase(EconomicShockStatus.LocalEconomicShock, EconomicShockStatus.LocalEconomicShock)]
+    [TestCase(EconomicShockStatus.NotApplicable, EconomicShockStatus.NotApplicable)]
+    [TestCase(null, EconomicShockStatus.NotApplicable)]
+    public void SetDefaults_WithValues_SetsExpectedEconomicShockStatusValue(EconomicShockStatus? status,
+        EconomicShockStatus expected)
+    {
+        // Arrange
+        var employmentProgression = new Models.EmploymentProgression
+        {
+            EconomicShockStatus = status
+        };
+
+        // Act
+        _sut.SetDefaults(employmentProgression, "ANY_STRING");
+
+        // Assert
+        Assert.AreEqual(expected, employmentProgression.EconomicShockStatus);
+    }
+
+    [Test]
+    public void SetDefaults_WithValues_SetsExpectedCreatedBy()
+    {
+        // Arrange
+        var expected = "100000000";
+        var employmentProgression = new Models.EmploymentProgression();
+
+        // Act
+        _sut.SetDefaults(employmentProgression, expected);
+
+        // Assert
+        Assert.AreEqual(expected, employmentProgression.CreatedBy);
+    }
+
+    [Test]
+    public void SetDefaults_WithNullValues_SetsExpectedDateProgressionRecorded()
+    {
+        // Arrange
+        var employmentProgression = new Models.EmploymentProgression
+        {
+            DateProgressionRecorded = null
+        };
+
+        // Act
+        _sut.SetDefaults(employmentProgression, "ANY_STRING");
+
+        // Assert
+        Assert.IsNotNull(employmentProgression.DateProgressionRecorded);
+    }
+
+    [Test]
+    public void SetDefaults_WithValues_DoesNotSetExpectedDateProgressionRecorded()
+    {
+        // Arrange
+        var expected = new DateTime(2000, 1, 1);
+        var employmentProgression = new Models.EmploymentProgression
+        {
+            DateProgressionRecorded = expected
+        };
+
+        // Act
+        _sut.SetDefaults(employmentProgression, "ANY_STRING");
+
+        // Assert
+        Assert.AreEqual(expected, employmentProgression.DateProgressionRecorded);
+    }
+}

--- a/NCS.DSS.EmploymentProgression/Models/EmploymentProgression.cs
+++ b/NCS.DSS.EmploymentProgression/Models/EmploymentProgression.cs
@@ -33,9 +33,8 @@ namespace NCS.DSS.EmploymentProgression.Models
         [Required]
         public CurrentEmploymentStatus? CurrentEmploymentStatus { get; set; }
 
-        [Display(Description = "Economic shock status.")]
-        [Example(Description = "2")]
-        [Required]
+        [Display(Description = "Economic shock status. Defaults to 3 if not provided")]
+        [Example(Description = "3")]
         public EconomicShockStatus? EconomicShockStatus { get; set; }
 
         [RegularExpression(@"^[^<>]+$")]

--- a/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/EmploymentProgressionPostTriggerService.cs
+++ b/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/EmploymentProgressionPostTriggerService.cs
@@ -5,6 +5,7 @@ using NCS.DSS.EmploymentProgression.ServiceBus;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using NCS.DSS.EmploymentProgression.ReferenceData;
 
 namespace NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service
 {
@@ -58,11 +59,8 @@ namespace NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service
         public void SetDefaults(Models.EmploymentProgression employmentProgression, string touchpointId)
         {
             employmentProgression.CreatedBy = touchpointId;
-
-            if (!employmentProgression.DateProgressionRecorded.HasValue)
-            {
-                employmentProgression.DateProgressionRecorded = DateTime.UtcNow;
-            }
+            employmentProgression.DateProgressionRecorded ??= DateTime.UtcNow;
+            employmentProgression.EconomicShockStatus ??= EconomicShockStatus.NotApplicable;
         }
 
         public void SetLongitudeAndLatitude(Models.EmploymentProgression employmentProgressionRequest, Position position)


### PR DESCRIPTION
Updated Economic Shock Status to  no longer be mandatory and default to 3 is not supplied in patch request.