### PR TITLE
AD-260954: Migrate from Azure Maps to Ordnance Survey

### DIFF
--- a/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPatchTriggerTests.cs
+++ b/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPatchTriggerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NCS.DSS.EmployeeProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
 using NCS.DSS.EmploymentProgression.Function;
 using NCS.DSS.EmploymentProgression.Models;
@@ -16,6 +15,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading.Tasks;
+using NCS.DSS.EmploymentProgression.GeoCoding;
 
 namespace NCS.DSS.EmploymentProgression.Tests.FunctionTests
 {

--- a/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPostTriggerTests.cs
+++ b/NCS.DSS.EmploymentProgression.Tests/FunctionTests/EmploymentProgressionPostTriggerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NCS.DSS.EmployeeProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
 using NCS.DSS.EmploymentProgression.Models;
 using NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service;
@@ -15,6 +14,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Threading.Tasks;
+using NCS.DSS.EmploymentProgression.GeoCoding;
 
 namespace NCS.DSS.EmploymentProgression.Tests.FunctionTests
 {

--- a/NCS.DSS.EmploymentProgression/GeoCoding/GeoCodingService.cs
+++ b/NCS.DSS.EmploymentProgression/GeoCoding/GeoCodingService.cs
@@ -1,18 +1,17 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
-using DFC.GeoCoding.Standard.AzureMaps.Service;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Services;
 using Microsoft.Extensions.Logging;
 
-namespace NCS.DSS.EmployeeProgression.GeoCoding
+namespace NCS.DSS.EmploymentProgression.GeoCoding
 {
     public class GeoCodingService : IGeoCodingService
     {
-        private readonly IAzureMapService _azureMapService;
-
+        private readonly IOSService _OSService;
         private readonly ILogger<GeoCodingService> _logger;
 
-        public GeoCodingService(IAzureMapService azureMapService, ILogger<GeoCodingService> logger)
+        public GeoCodingService(IOSService OSService, ILogger<GeoCodingService> logger)
         {
-            _azureMapService = azureMapService;
+            _OSService = OSService;
             _logger = logger;
         }
 
@@ -24,10 +23,10 @@ namespace NCS.DSS.EmployeeProgression.GeoCoding
             try
             {
                 _logger.LogTrace("Attempting to Get Position of Postcode {PostCode}", postcode);
-                var position = await _azureMapService.GetPositionForAddress(postcode);
+                var position = await _OSService.GetPositionForPostcodeAsync(postcode);
                 if(position != null)
                 {
-                    _logger.LogTrace("Successfully Retrieved Position {Long}/{Lat} of Postcode {PostCode}",position.Lon,position.Lat, postcode);
+                    _logger.LogTrace("Successfully Retrieved Position {Long}/{Lat} of Postcode {PostCode}",position.Longitude, position.Latitude, postcode);
                     return position;
                 }
                 _logger.LogInformation("Failed to Retrieve Position of Postcode {PostCode}", postcode);

--- a/NCS.DSS.EmploymentProgression/GeoCoding/IGeoCodingService.cs
+++ b/NCS.DSS.EmploymentProgression/GeoCoding/IGeoCodingService.cs
@@ -1,6 +1,6 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 
-namespace NCS.DSS.EmployeeProgression.GeoCoding
+namespace NCS.DSS.EmploymentProgression.GeoCoding
 {
     public interface IGeoCodingService
     {

--- a/NCS.DSS.EmploymentProgression/Models/EmploymentProgression.cs
+++ b/NCS.DSS.EmploymentProgression/Models/EmploymentProgression.cs
@@ -61,13 +61,13 @@ namespace NCS.DSS.EmploymentProgression.Models
         [Example(Description = "AA11AA")]
         public string EmployerPostcode { get; set; }
 
-        [RegularExpression(@"^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$")]
+        [RegularExpression(@"^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,8})?))$")]
         [Display(Description = "Geocoded address information")]
         [Example(Description = "52.40100")]
         [JsonIgnoreOnSerialize]
         public decimal? Latitude { get; set; }
 
-        [RegularExpression(@"^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$")]
+        [RegularExpression(@"^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,8})?))$")]
         [Display(Description = "Geocoded address information")]
         [Example(Description = "-1.50812")]
         [JsonIgnoreOnSerialize]

--- a/NCS.DSS.EmploymentProgression/Models/EmploymentProgressionConfigurationSettings.cs
+++ b/NCS.DSS.EmploymentProgression/Models/EmploymentProgressionConfigurationSettings.cs
@@ -9,13 +9,11 @@
         public string BaseAddress { get; set; }
         public string QueueName { get; set; }
         public string ServiceBusConnectionString { get; set; }
-        public string AzureMapURL { get; set; }
-        public string AzureMapApiVersion { get; set; }
-        public string AzureMapSubscriptionKey { get; set; }
-        public string AzureCountrySet { get; set; }
         public string DatabaseId { get; set; }
         public string CollectionId { get; set; }
         public string CustomerDatabaseId { get; set; }
         public string CustomerCollectionId { get; set; }
+        public string OSServiceApiUrl { get; set; }
+        public string OSServiceApiKey { get; set; }
     }
 }

--- a/NCS.DSS.EmploymentProgression/NCS.DSS.EmploymentProgression.csproj
+++ b/NCS.DSS.EmploymentProgression/NCS.DSS.EmploymentProgression.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
-    <PackageReference Include="DFC.GeoCoding.Standard" Version="1.0.5" />
+    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.0.0" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />

--- a/NCS.DSS.EmploymentProgression/NCS.DSS.EmploymentProgression.csproj
+++ b/NCS.DSS.EmploymentProgression/NCS.DSS.EmploymentProgression.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
-    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.0.0" />
+    <PackageReference Include="DFC.GeoCoding.Standard" Version="2.1.0" />
     <PackageReference Include="DFC.HTTP.Standard" Version="0.1.11" />
     <PackageReference Include="DFC.Swagger.Standard" Version="0.1.36" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />

--- a/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Function/EmploymentProgressionPatchTrigger.cs
+++ b/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Function/EmploymentProgressionPatchTrigger.cs
@@ -1,13 +1,12 @@
-using Azure.Core;
-using DFC.GeoCoding.Standard.AzureMaps.Model;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using NCS.DSS.EmployeeProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
+using NCS.DSS.EmploymentProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Models;
 using NCS.DSS.EmploymentProgression.PatchEmploymentProgression.Service;
 using NCS.DSS.EmploymentProgression.Validators;

--- a/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Service/EmploymentProgressionPatchTriggerService.cs
+++ b/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Service/EmploymentProgressionPatchTriggerService.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
 using NCS.DSS.EmploymentProgression.Models;
 using NCS.DSS.EmploymentProgression.ServiceBus;
@@ -73,8 +73,8 @@ namespace NCS.DSS.EmploymentProgression.PatchEmploymentProgression.Service
                 return;
             }
 
-            employmentProgressionPatchRequest.Longitude = (decimal)position.Lon;
-            employmentProgressionPatchRequest.Latitude = (decimal)position.Lat;
+            employmentProgressionPatchRequest.Longitude = (decimal)position.Longitude;
+            employmentProgressionPatchRequest.Latitude = (decimal)position.Latitude;
         }
     }
 }

--- a/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Service/IEmploymentProgressionPatchTriggerService.cs
+++ b/NCS.DSS.EmploymentProgression/PatchEmploymentProgression/Service/IEmploymentProgressionPatchTriggerService.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using NCS.DSS.EmploymentProgression.Models;
 
 namespace NCS.DSS.EmploymentProgression.PatchEmploymentProgression.Service

--- a/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Function/EmploymentProgressionPostTrigger.cs
+++ b/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Function/EmploymentProgressionPostTrigger.cs
@@ -1,13 +1,12 @@
-using DFC.GeoCoding.Standard.AzureMaps.Model;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.HTTP.Standard;
 using DFC.Swagger.Standard.Annotations;
-using Grpc.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using NCS.DSS.EmployeeProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
+using NCS.DSS.EmploymentProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Models;
 using NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service;
 using NCS.DSS.EmploymentProgression.Validators;

--- a/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/EmploymentProgressionPostTriggerService.cs
+++ b/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/EmploymentProgressionPostTriggerService.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
 using NCS.DSS.EmploymentProgression.ReferenceData;
 using NCS.DSS.EmploymentProgression.ServiceBus;
@@ -67,8 +67,8 @@ namespace NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service
                 return;
             }
 
-            employmentProgressionRequest.Longitude = (decimal)position.Lon;
-            employmentProgressionRequest.Latitude = (decimal)position.Lat;
+            employmentProgressionRequest.Longitude = (decimal)position.Longitude;
+            employmentProgressionRequest.Latitude = (decimal)position.Latitude;
         }
     }
 }

--- a/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/IEmploymentProgressionPostTriggerService.cs
+++ b/NCS.DSS.EmploymentProgression/PostEmploymentProgression/Service/IEmploymentProgressionPostTriggerService.cs
@@ -1,4 +1,4 @@
-﻿using DFC.GeoCoding.Standard.AzureMaps.Model;
+﻿using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 
 namespace NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service
 {

--- a/NCS.DSS.EmploymentProgression/Program.cs
+++ b/NCS.DSS.EmploymentProgression/Program.cs
@@ -1,6 +1,5 @@
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
-using DFC.GeoCoding.Standard.AzureMaps.Service;
 using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
 using DFC.GeoCoding.Standard.OrdnanceSurvey.Services;
 using DFC.HTTP.Standard;
@@ -99,7 +98,6 @@ namespace NCS.DSS.EmploymentProgression
                     services.AddTransient<IValidate, Validate>();
                     services.AddScoped<ISwaggerDocumentGenerator, SwaggerDocumentGenerator>();
                     services.AddScoped<IGeoCodingService, GeoCodingService>();
-                    services.AddScoped<IAzureMapService, AzureMapService>();
 
                     services.AddSingleton<IHttpRequestHelper, HttpRequestHelper>();
                     services.AddSingleton<IJsonHelper, JsonHelper>();

--- a/NCS.DSS.EmploymentProgression/Program.cs
+++ b/NCS.DSS.EmploymentProgression/Program.cs
@@ -1,17 +1,20 @@
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using DFC.GeoCoding.Standard.AzureMaps.Service;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Models;
+using DFC.GeoCoding.Standard.OrdnanceSurvey.Services;
 using DFC.HTTP.Standard;
 using DFC.JSON.Standard;
 using DFC.Swagger.Standard;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Azure.Functions.Worker;
-using NCS.DSS.EmployeeProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.Cosmos.Provider;
+using NCS.DSS.EmploymentProgression.GeoCoding;
 using NCS.DSS.EmploymentProgression.GetEmploymentProgression.Service;
 using NCS.DSS.EmploymentProgression.GetEmploymentProgressionById.Service;
 using NCS.DSS.EmploymentProgression.Models;
@@ -19,7 +22,7 @@ using NCS.DSS.EmploymentProgression.PatchEmploymentProgression.Service;
 using NCS.DSS.EmploymentProgression.PostEmploymentProgression.Service;
 using NCS.DSS.EmploymentProgression.ServiceBus;
 using NCS.DSS.EmploymentProgression.Validators;
-using Microsoft.Extensions.Configuration;
+
 namespace NCS.DSS.EmploymentProgression
 {
     internal class Program
@@ -40,6 +43,14 @@ namespace NCS.DSS.EmploymentProgression
                     var configuration = context.Configuration;
                     services.AddOptions<EmploymentProgressionConfigurationSettings>()
                         .Bind(configuration);
+                    services.Configure<OSServiceOptions>(options =>
+                    {
+                        var settings = configuration.Get<EmploymentProgressionConfigurationSettings>();
+                        options.ApiUrl = settings.OSServiceApiUrl;
+                        options.ApiKey = settings.OSServiceApiKey;
+                    });
+
+                    services.AddHttpClient<IOSService, OSService>();
                     services.AddLogging();
                     services.AddApplicationInsightsTelemetryWorkerService();
                     services.ConfigureFunctionsApplicationInsights();

--- a/Resources/AzureDevOps/azure-pipelines.yml
+++ b/Resources/AzureDevOps/azure-pipelines.yml
@@ -9,7 +9,7 @@ resources:
   - repository: dfc-devops
     type: github
     name: SkillsFundingAgency/dfc-devops
-    ref: refs/tags/v1.16.2
+    ref: refs/tags/v1.16.7
     endpoint: 'GitHub (CDH)'
 
 pool:
@@ -54,7 +54,7 @@ jobs:
       SolutionBaseName: $(SolutionBaseName)
       BuildPlatform: $(BuildPlatform)
       BuildConfiguration: $(BuildConfiguration)
-      GitVersionVersion: 5.12.x
+      GitVersionVersion: 6.6.x
       DotNetCoreVersion: 8.x
 
 

--- a/Resources/template.json
+++ b/Resources/template.json
@@ -72,11 +72,9 @@
                 "ServiceBusConnectionString": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=ServiceBusConnectionString)', parameters('keyVaultName'))]",
                 "ChangeFeedQueueName": "dss.changefeedqueue",
                 "QueueName": "[parameters('serviceBusQueueName')]",
-                "AzureMapURL": "https://atlas.microsoft.com/search",
-                "AzureMapApiVersion": "1.0",
-                "AzureMapSubscriptionKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=AzureMapsAccessKey)', parameters('keyVaultName'))]",
-                "AzureCountrySet": "GB",
-                "CosmosDbEndpoint": "[parameters('CosmosDbEndpoint')]"
+                "CosmosDbEndpoint": "[parameters('CosmosDbEndpoint')]",
+				"OSServiceApiUrl": "https://api.os.uk/search/places/v1/postcode?postcode={0}&dataset=DPA&output_srs=WGS84",
+				"OSServiceApiKey": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=GetPostCodeApiKey)', parameters('keyVaultName'))]"
             },
             "copy": {
                 "name": "FunctionAppSettingsCopy",


### PR DESCRIPTION
This pull request updates the geocoding implementation in the `NCS.DSS.EmploymentProgression` project, switching from Azure Maps to Ordnance Survey (OS) services. The changes affect service logic, configuration, dependency injection, and related test and interface files. Additionally, it updates some build and deployment pipeline settings.

**Migration from Azure Maps to Ordnance Survey for Geocoding:**

* Updated all references and usage from `DFC.GeoCoding.Standard.AzureMaps` to `DFC.GeoCoding.Standard.OrdnanceSurvey` throughout the codebase, including models, services, and method calls. The main geocoding service now uses `IOSService` and the OS API instead of `IAzureMapService` and Azure Maps.

* Changed the longitude and latitude property assignments to use `position.Longitude` and `position.Latitude` instead of `position.Lon` and `position.Lat` to match the Ordnance Survey model.

**Configuration and Dependency Injection:**

* Replaced Azure Maps configuration settings with Ordnance Survey API settings in `EmploymentProgressionConfigurationSettings` and related ARM template files. Now uses `OSServiceApiUrl` and `OSServiceApiKey`.

* Updated dependency injection in `Program.cs` to register `IOSService` and configure `OSServiceOptions` using the new configuration values.

**Build and Pipeline Updates:**

* Upgraded the `DFC.GeoCoding.Standard` NuGet package from version 1.0.5 to 2.1.0 to support Ordnance Survey.

* Updated Azure DevOps pipeline to use newer versions of `dfc-devops` and `GitVersion`.

These changes collectively ensure that all geocoding functionality now uses Ordnance Survey instead of Azure Maps, with appropriate configuration, dependency injection, and compatibility updates across the codebase.